### PR TITLE
Potential fix for code scanning alert no. 33: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ module.exports = function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/ghejzorg/juice-shop/security/code-scanning/33](https://github.com/ghejzorg/juice-shop/security/code-scanning/33)

To fix the problem, we should avoid using the `$where` operator with user-provided input. Instead, we can use a parameterized query to safely query the database. This approach ensures that user input is treated as data rather than code, preventing code injection attacks.

We will replace the `$where` query with a standard query using the `orderId` field. This change will be made in the `routes/trackOrder.ts` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
